### PR TITLE
RPCProtocol.RPC_HTTPS causing "java.net.socketexception unexpected end of file from server"

### DIFF
--- a/src/com/debortoliwines/openerp/api/Session.java
+++ b/src/com/debortoliwines/openerp/api/Session.java
@@ -219,7 +219,7 @@ public class Session {
 	 * @throws XmlRpcException
 	 */
 	public Version getServerVersion() throws XmlRpcException{
-	  return OpenERPXmlRpcProxy.getServerVersion(host, port);
+	  return OpenERPXmlRpcProxy.getServerVersion(protocol, host, port);
 	}
 	
 	/**


### PR DESCRIPTION
When we use:

```java
Session session = new Session(RPCProtocol.RPC_HTTPS, .... );
}
```

We got 
````java
 java.net.socketexception unexpected end of file from server 
....
````

Our analysis found that this is probably because `ObjectAdapter`'s constructor blindly use `Session.getServerVersion()`, where `#getServerVersion()` implementation not using `Session.protocol` attribute in its implementation (see original code). 

This pull request attempt to solve this problem.