### PR TITLE
Remove generation of a doc zip.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -54,11 +54,6 @@
 			</manifest>
 
 		</jar>
-		
-		<!-- Create java docs -->
-		<zip destfile="${dist}/openerp-java-api-${version}-javadocs.zip"
-		       basedir="doc"
-		  />
 	</target>
 	<target name="rebuild" depends="compile" />
 </project>


### PR DESCRIPTION
There is no target that creates the doc directory, so depending on its
existence causes the entire dist target to fail.