### PR TITLE
Fixed getServerVersion sent in plaintext even with HTTPS

### DIFF
--- a/src/com/debortoliwines/openerp/api/Session.java
+++ b/src/com/debortoliwines/openerp/api/Session.java
@@ -219,7 +219,7 @@ public class Session {
 	 * @throws XmlRpcException
 	 */
 	public Version getServerVersion() throws XmlRpcException{
-	  return OpenERPXmlRpcProxy.getServerVersion(host, port);
+	  return OpenERPXmlRpcProxy.getServerVersion(protocol, host, port);
 	}
 	
 	/**


### PR DESCRIPTION
This is the exception seen when this problem occurs:

org.apache.xmlrpc.client.XmlRpcHttpTransportException: HTTP server
returned unexpected status: Bad Request

closes DeBortoliWines/openerp-java-api#8