### PR TITLE
[10.0]Explicit context in RPC call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.debortoliwines</groupId>
   <artifactId>odoo-java-api</artifactId>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
   <packaging>jar</packaging>
 
   <name>odoo-java-api</name>

--- a/src/main/java/com/debortoliwines/odoo/api/OdooCommand.java
+++ b/src/main/java/com/debortoliwines/odoo/api/OdooCommand.java
@@ -78,7 +78,7 @@ public class OdooCommand {
         Object orderParam = order == null || order.length() == 0 ? false : order;
         // Before Odoo 10 there's a 'context' parameter between order and count
         Object[] params = (this.session.getServerVersion().getMajor() < 10)
-                ? new Object[]{filter, offsetParam, limitParam, orderParam, false, count}
+                ? new Object[]{filter, offsetParam, limitParam, orderParam, session.getContext(), count}
                 : new Object[]{filter, offsetParam, limitParam, orderParam, count};
 
         try {
@@ -204,7 +204,7 @@ public class OdooCommand {
     public Object createObject(String objectName, Map<String, Object> values) throws XmlRpcException {
         Object readResult ;
         if (this.session.getServerVersion().getMajor() >= 8 ) {
-            readResult = (Object) session.executeCommand(objectName, "create", new Object[]{values});
+            readResult = (Object) session.executeCommand(objectName, "create", new Object[]{values, session.getContext()});
         } else {
             readResult = (Object) session.executeCommand(objectName, "create", new Object[]{values, session.getContext()});
         }

--- a/src/main/java/com/debortoliwines/odoo/api/OdooXmlRpcProxy.java
+++ b/src/main/java/com/debortoliwines/odoo/api/OdooXmlRpcProxy.java
@@ -104,8 +104,10 @@ public class OdooXmlRpcProxy extends XmlRpcClient {
 
 		XmlRpcClientConfigImpl xmlrpcConfigLogin = new XmlRpcClientConfigImpl();
 		
-		// Odoo does not support extensions
-		xmlrpcConfigLogin.setEnabledForExtensions(false);
+		// Odoo seems to be documented for supporting extensions
+                //https://doc.odoo.com/v6.0/developer/6_22_XML-RPC_web_services/index.html/
+                //https://www.odoo.com/fr_FR/forum/aide-1/question/using-openerp-xml-rpc-api-with-java-2872
+		xmlrpcConfigLogin.setEnabledForExtensions(true);
 		
 		// The URL is hardcoded and can not be malformed
 		try {

--- a/src/main/java/com/debortoliwines/odoo/api/Session.java
+++ b/src/main/java/com/debortoliwines/odoo/api/Session.java
@@ -25,6 +25,7 @@ import org.apache.xmlrpc.XmlRpcException;
 
 import com.debortoliwines.odoo.api.OdooXmlRpcProxy.RPCProtocol;
 import com.debortoliwines.odoo.api.OdooXmlRpcProxy.RPCServices;
+import java.util.Arrays;
 
 /**
  * *
@@ -235,12 +236,26 @@ public class Session {
         Object[] connectionParams = new Object[]{databaseName, userID, password, objectName, commandName};
 
         // Combine the connection parameters and command parameters
+//        Object[] params;
+//        if ()
         Object[] params = new Object[connectionParams.length + (parameters == null ? 0 : parameters.length)];
         System.arraycopy(connectionParams, 0, params, 0, connectionParams.length);
 
         if (parameters != null && parameters.length > 0) {
             System.arraycopy(parameters, 0, params, connectionParams.length, parameters.length);
         }
+        if (this.getServerVersion().getMajor() == 9 && this.context.size() > 0) {
+            Integer initial_length = params.length;
+            params = Arrays.copyOf(params, initial_length + this.context.size());
+            System.arraycopy(this.context.toString(), 0, params, initial_length, this.context.size());
+        }
+
+        //Try to always deal with the context
+//        (this.getServerVersion().getMajor() < 10)
+//                ? new Object[]{filter, offsetParam, limitParam, orderParam, false, count}
+//                : new Object[]{filter, offsetParam, limitParam, orderParam, count};
+//        this.getServerVersion()
+//        System.arraycopy(this.getContext(), 0, params, connectionParams.length, parameters.length);
         return objectClient.execute("execute", params);
     }
 


### PR DESCRIPTION
Hi @xsalefter , @gjvoosten ,

A review on this would be appreciated.
The purpose is to explicit the command to execute with or without the context.
For example, create method in v9 keep some additionnal parameters that prevent us to be generic with the v8. I had those kind of issues in the stock module AFAIR.
