### PR TITLE
Better handling of comma seperated list

### DIFF
--- a/src/main/java/com/odoojava/api/ObjectAdapter.java
+++ b/src/main/java/com/odoojava/api/ObjectAdapter.java
@@ -522,7 +522,7 @@ public class ObjectAdapter {
                     String newValue = "";
                     // Comma separated list of IDs
                     if (value instanceof String) {
-                        for (String singleID : value.toString().split(",")) {
+                        for (String singleID : value.toString().split("\s*,[,\s]*")) {
                             if (idToName.containsKey(singleID)) {
                                 newValue = newValue + "," + idToName.get(singleID);
                             } else {


### PR DESCRIPTION
Comma separated list of ids might have space(s) in certain cases (e.g if prepared with Group By step).  Since this splits strictly with comma, it cannot find following ids. This patch allows handling of spaces properly.