### PR TITLE
[FIX] Dates should not take into account the timezone

### DIFF
--- a/src/main/java/com/odoojava/api/Row.java
+++ b/src/main/java/com/odoojava/api/Row.java
@@ -130,6 +130,7 @@ public class Row {
 		
 		if (value instanceof String && fieldType == Field.FieldType.DATE){
 			DateFormat dfm = new SimpleDateFormat("yyyy-MM-dd");
+			dfm.setTimeZone(TimeZone.getTimeZone("UTC"));
 			try{
 				return dfm.parse(value.toString());
 			}
@@ -140,6 +141,7 @@ public class Row {
 		
 		if (value instanceof String && fieldType == Field.FieldType.DATETIME){
 			DateFormat dfm = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+			dfm.setTimeZone(TimeZone.getTimeZone("UTC"));
 			try{
 				return dfm.parse(value.toString());
 			}


### PR DESCRIPTION
Hi,

First of all congratulations for the tool!

We found out this bug while using the Odoo plugin in Pentaho Data Integration (a.k.a. Kettle) made by @gjvoosten 
It's really useful, thanks for the tool!

However, during our tests we realized that dates were initialized without timezone and it takes the one of the system. Since Odoo stores its date and datetimes fields without timezone, we think it make sense to initialize the timezone of the date/datetimes read as UTC

Regards